### PR TITLE
feat: add session recording alert rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,24 @@ juju config auditd enable_session_recording=false
   unrecorded (the tlog pty layer would corrupt binary framing). They are still covered by auditd
   path-watch rules.
 
+### Tamper detection & alerting
+
+auditd watches these session-recording assets:
+- recording file and its rotated copies
+- tlog and sshd config
+- sshd drop-in for tlog-wrapper ForceCommand
+- tlog wrapper
+- setuid recorder binary
+- logrotate config,
+- the audit rules themselves
+and records all writes/attribute changes.
+
+Loki alert rules turn the audit logs into pages, but the alerts are paging only on **interactive**
+tampering, which is distinguished by the audit `auid` (login uid). The charm's own legitimate
+activities run in daemon context (`auid` unset) and should be suppressed at the pager while still
+being recorded in the audit log.
+
+
 ### Replay
 
 All sessions share one file; each recording is identified by its `rec` field. List the

--- a/src/loki_alert_rules/audit.yaml
+++ b/src/loki_alert_rules/audit.yaml
@@ -72,9 +72,9 @@ groups:
       count by (instance, tkey, juju_model, juju_model_uuid) (
         count_over_time({filename=~"/var/log/audit/audit\\.log.*"}
         |~ `type=SYSCALL`
-        |~ `key="(tlog_recording_tamper|tlog_config_tamper|sshd_dropin_tamper|tlog_wrapper_tamper|tlog_recorder_tamper|tlog_logrotate_tamper|sshd_main_config_tamper)"`
+        |~ `(tlog_recording_tamper|tlog_config_tamper|sshd_dropin_tamper|tlog_wrapper_tamper|tlog_recorder_tamper|tlog_logrotate_tamper|sshd_main_config_tamper)`
         | regexp `auid=(?P<auid>[0-9]+)`
-        | regexp `key="(?P<tkey>[a-z_]+)"`
+        | regexp `key=.(?P<tkey>[a-z_]+)`
         | auid != `4294967295` [5m])
       ) > 0
     labels:
@@ -94,7 +94,7 @@ groups:
       count by (instance, juju_model, juju_model_uuid) (
         count_over_time({filename=~"/var/log/audit/audit\\.log.*"}
         |~ `type=SYSCALL`
-        |~ `key="audit_rules_tamper"`
+        |~ `audit_rules_tamper`
         | regexp `auid=(?P<auid>[0-9]+)`
         | auid != `4294967295` [5m])
       ) > 0
@@ -113,7 +113,7 @@ groups:
       count by (instance, juju_model, juju_model_uuid) (
         count_over_time({filename=~"/var/log/audit/audit\\.log.*"}
         |~ `type=SYSCALL`
-        |~ `key="sshd_execve"` [5m])
+        |~ `sshd_execve` [5m])
       ) > 0
     labels:
       severity: warning

--- a/src/loki_alert_rules/audit.yaml
+++ b/src/loki_alert_rules/audit.yaml
@@ -75,7 +75,7 @@ groups:
         |~ `(tlog_recording_tamper|tlog_config_tamper|sshd_dropin_tamper|tlog_wrapper_tamper|tlog_recorder_tamper|tlog_logrotate_tamper|sshd_main_config_tamper)`
         | regexp `auid=(?P<auid>[0-9]+)`
         | regexp `key=.(?P<tkey>[a-z_]+)`
-        | auid != `4294967295` [5m])
+        | auid != `4294967295` [1h])
       ) > 0
     labels:
       severity: critical
@@ -96,7 +96,7 @@ groups:
         |~ `type=SYSCALL`
         |~ `audit_rules_tamper`
         | regexp `auid=(?P<auid>[0-9]+)`
-        | auid != `4294967295` [5m])
+        | auid != `4294967295` [1h])
       ) > 0
     labels:
       severity: critical
@@ -113,7 +113,7 @@ groups:
       count by (instance, juju_model, juju_model_uuid) (
         count_over_time({filename=~"/var/log/audit/audit\\.log.*"}
         |~ `type=SYSCALL`
-        |~ `sshd_execve` [5m])
+        |~ `sshd_execve` [1h])
       ) > 0
     labels:
       severity: warning

--- a/src/loki_alert_rules/audit.yaml
+++ b/src/loki_alert_rules/audit.yaml
@@ -87,6 +87,7 @@ groups:
         recording asset - the recording file, rotated recordings, tlog/sshd config, the sshd
         drop-in, the tlog wrapper, the setuid recorder binary, or the logrotate config. Recordings
         may have been altered or disabled.
+        Check the event with "sudo ausearch -k {{ $labels.tkey }}".
 
           LABELS = {{ $labels }}
   - alert: AuditRulesTampered
@@ -106,6 +107,7 @@ groups:
         An auditd watch fired for key 'audit_rules_tamper' on {{ $labels.instance }} from an
         interactive session - a write or attribute change under /etc/audit/rules.d/.
         Tampering the audit rules can blind every other tamper alert.
+        Check the event with "sudo ausearch -k audit_rules_tamper".
 
           LABELS = {{ $labels }}
   - alert: SshdLaunchedFromSession
@@ -122,5 +124,6 @@ groups:
       description: |
         sshd was executed from an interactive login session on {{ $labels.instance }}.
         A second sshd instance launched from a session could bypass session recording.
+        Check the event with "sudo ausearch -k sshd_execve".
 
           LABELS = {{ $labels }}

--- a/src/loki_alert_rules/audit.yaml
+++ b/src/loki_alert_rules/audit.yaml
@@ -67,3 +67,60 @@ groups:
         The linux user account had been changed on {{ $labels.instance }} in the past 3 days. The file '{{ $labels.name }}' was {{ $labels.nametype }}D. Operators are suggested to check the relevant logs to find out what was changed.
 
           LABELS = {{ $labels }}
+  - alert: RecordingAssetTampered
+    expr: |
+      count by (instance, tkey, juju_model, juju_model_uuid) (
+        count_over_time({filename=~"/var/log/audit/audit\\.log.*"}
+        |~ `type=SYSCALL`
+        |~ `key="(tlog_recording_tamper|tlog_config_tamper|sshd_dropin_tamper|tlog_wrapper_tamper|tlog_recorder_tamper|tlog_logrotate_tamper|sshd_main_config_tamper)"`
+        | regexp `auid=(?P<auid>[0-9]+)`
+        | regexp `key="(?P<tkey>[a-z_]+)"`
+        | auid != `4294967295` [5m])
+      ) > 0
+    labels:
+      severity: critical
+    annotations:
+      summary: tlog recording asset tampered on {{ $labels.instance }}
+      description: |
+        An auditd watch fired for key '{{ $labels.tkey }}' on {{ $labels.instance }} from an
+        interactive session. This indicates a write or attribute change on a session
+        recording asset - the recording file, rotated recordings, tlog/sshd config, the sshd
+        drop-in, the tlog wrapper, the setuid recorder binary, or the logrotate config. Recordings
+        may have been altered or disabled.
+
+          LABELS = {{ $labels }}
+  - alert: AuditRulesTampered
+    expr: |
+      count by (instance, juju_model, juju_model_uuid) (
+        count_over_time({filename=~"/var/log/audit/audit\\.log.*"}
+        |~ `type=SYSCALL`
+        |~ `key="audit_rules_tamper"`
+        | regexp `auid=(?P<auid>[0-9]+)`
+        | auid != `4294967295` [5m])
+      ) > 0
+    labels:
+      severity: critical
+    annotations:
+      summary: auditd rules tampered on {{ $labels.instance }}
+      description: |
+        An auditd watch fired for key 'audit_rules_tamper' on {{ $labels.instance }} from an
+        interactive session - a write or attribute change under /etc/audit/rules.d/.
+        Tampering the audit rules can blind every other tamper alert.
+
+          LABELS = {{ $labels }}
+  - alert: SshdLaunchedFromSession
+    expr: |
+      count by (instance, juju_model, juju_model_uuid) (
+        count_over_time({filename=~"/var/log/audit/audit\\.log.*"}
+        |~ `type=SYSCALL`
+        |~ `key="sshd_execve"` [5m])
+      ) > 0
+    labels:
+      severity: warning
+    annotations:
+      summary: sshd launched from a login session on {{ $labels.instance }}
+      description: |
+        sshd was executed from an interactive login session on {{ $labels.instance }}.
+        A second sshd instance launched from a session could bypass session recording.
+
+          LABELS = {{ $labels }}

--- a/src/tlog_templates/tlog.rules
+++ b/src/tlog_templates/tlog.rules
@@ -1,10 +1,14 @@
 # Tamper detection for tlog session recording.
-# These rules fire on writes/truncations to the recording file and config dirs,
+# These rules fire on writes/truncations to the recording assets and config,
 # and on anomalous sshd execve (second-sshd bypass).
 #
 # Installed/removed together with session recording: the watched paths only
 # exist while recording is configured, so the rules below are only active when
 # recording is active.
+#
+# The rules record ALL writes/attribute changes - including the charm's own
+# legitimate chmod/chattr/writes. A complete audit trail is the goal; the
+# legitimate-vs-tamper distinction should be made at the Loki alert layer.
 
 # Recording file: watch for write/attribute changes (truncation, chmod, chown).
 -w /var/log/tlog/sessions.log -p wa -k tlog_recording_tamper
@@ -12,12 +16,31 @@
 # Writes within the log dir (e.g. creating a replacement file).
 -a always,exit -F dir=/var/log/tlog -F perm=wa -k tlog_recording_tamper
 
+# Explicit unlink/rename coverage for the log dir
+-a always,exit -F dir=/var/log/tlog -F perm=wa -S unlink,unlinkat,rename,renameat,renameat2 -k tlog_recording_tamper
+
 # Config dirs: watch for modifications to tlog and sshd drop-in config.
--w /etc/tlog/ -p wa -k tlog_config_tamper
--w /etc/ssh/sshd_config.d/ -p wa -k sshd_dropin_tamper
+-a always,exit -F dir=/etc/tlog/ -F perm=wa -k tlog_config_tamper
+-a always,exit -F dir=/etc/ssh/sshd_config.d/ -F perm=wa -k sshd_dropin_tamper
+
+# Main sshd config: the drop-in is only effective via the
+# `Include /etc/ssh/sshd_config.d/*.conf` directive. Deleting that Include (or
+# adding an overriding directive here) bypasses recording WITHOUT touching the
+# watched drop-in dir, so watch the parent file too.
+-w /etc/ssh/sshd_config -p wa -k sshd_main_config_tamper
 
 # Watch for write/attribute changes in the tlog wrapper.
 -w /usr/local/bin/tlog-wrapper -p wa -k tlog_wrapper_tamper
+
+# Setuid recorder binary: stripping the setuid bit (chmod, an attribute change)
+# or overwriting the binary in place (write) disables or swaps the recorder.
+-w /usr/bin/tlog-rec-session -p wa -k tlog_recorder_tamper
+
+# Logrotate config: a malicious rotate/compress/postrotate can wipe recordings.
+-w /etc/logrotate.d/tlog -p wa -k tlog_logrotate_tamper
+
+# Audit rules dir: detect tamper of the rules that detect everything else
+-a always,exit -F dir=/etc/audit/rules.d/ -F perm=wa -k audit_rules_tamper
 
 # sshd execve: legitimate sshd executions (boot, systemd restart, per-connection
 # re-exec) happen before pam_loginuid assigns a login uid, so their auid is unset.


### PR DESCRIPTION
Add and improve audit rules to watch session recording assets (recording log, binary, config, etc.)

Add Loki alert rules to alert on tampering behaviors recorded in audit log. The Loki rules will not alert on activities done by the charm itself - though these will still be recorded in audit log.
 
This PR is based on the session recording implementation https://github.com/canonical/auditd-operator/pull/28, should merge after that PR.  The commits of this PR are counted from 1ef3782.