### PR TITLE
fix: re-emit the motd for interactive session login

### DIFF
--- a/src/tlog_templates/tlog_wrapper.sh.j2
+++ b/src/tlog_templates/tlog_wrapper.sh.j2
@@ -5,6 +5,14 @@
 user_shell=$(getent passwd "$(id -un)" | cut -d: -f7)
 [ -n "$user_shell" ] || user_shell=/bin/sh
 
+# sshd suppresses MOTD/login messages for ForceCommand sessions.
+# PAM still regenerates /run/motd.dynamic during session setup, so re-emit it
+# here for interactive logins.
+if [ -z "$SSH_ORIGINAL_COMMAND" ] && [ ! -e "$HOME/.hushlogin" ]; then
+  [ -s /run/motd.dynamic ] && cat /run/motd.dynamic 2>/dev/null
+  [ -s /etc/motd ] && cat /etc/motd 2>/dev/null
+fi
+
 # Fail open: never dead-end a login if the recorder is unavailable (a missing or
 # non-executable recorder must not lock everyone out). Drop into the real shell.
 [ -x /usr/bin/tlog-rec-session ] || exec "$user_shell"

--- a/tests/unit/test_tlog_workload.py
+++ b/tests/unit/test_tlog_workload.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -513,6 +514,28 @@ def test_wrapper_renders_exact_token_exclude_case():
     assert "id -nG" in out
     assert '*",g1,"*) exec "$user_shell" ;;' in out
     assert '*",sudo,"*) exec "$user_shell" ;;' in out
+
+
+def test_wrapper_reemits_motd_guarded_for_interactive_logins():
+    out = _render_wrapper("")
+    assert '[ -z "$SSH_ORIGINAL_COMMAND" ] && [ ! -e "$HOME/.hushlogin" ]' in out
+    assert "cat /run/motd.dynamic" in out
+    assert "cat /etc/motd" in out
+
+
+def test_wrapper_motd_block_independent_of_exclude_groups():
+    without = _render_wrapper("")
+    with_groups = _render_wrapper("g1,sudo")
+    guard = '[ -z "$SSH_ORIGINAL_COMMAND" ] && [ ! -e "$HOME/.hushlogin" ]'
+    assert guard in without
+    assert guard in with_groups
+
+
+@pytest.mark.parametrize("exclude_groups", ["", "g1,sudo"])
+def test_wrapper_renders_valid_posix_shell(exclude_groups):
+    out = _render_wrapper(exclude_groups)
+    result = subprocess.run(["sh", "-n"], input=out, capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
 
 
 @patch("tlog_workload.subprocess.run", return_value=MagicMock(returncode=0, stderr=""))


### PR DESCRIPTION
Fixes https://github.com/canonical/auditd-operator/issues/34