### PR TITLE
refactor: allow deploying on LXC for session recording only

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,15 @@ component to the  Linux Auditing System. It's responsible for writing audit reco
 
 ## Platform Requirements
 
-This charm can only be deployed on **bare metal machines or virtual machines**. It **cannot** be
-deployed on Linux containers (LXC).
-
 [`auditd`][1] performs kernel-level auditing and requires direct access to the kernel's audit
-subsystem, which is not available within containers. The charm will automatically prevent
-deployment on unsupported platforms (LXC containers) and raise an error during installation.
+subsystem, which is not available within Linux containers (LXC). Therefore **auditd runs only on
+bare metal machines or virtual machines**.
+
+On **LXC containers** the charm still deploys, but in **session-recording-only mode**: auditd is
+skipped and only [`tlog`][2] session recording runs (see [Session Recording](#session-recording)).
+Recording on containers is best-effort with no auditd tamper detection
+(See [security caveats](#security-caveats)). Because there is nothing to manage when recording is
+off, an LXC unit with `enable_session_recording=false` goes to a blocked state.
 
 [1]: https://manpages.ubuntu.com/manpages/noble/man8/auditd.8.html
 
@@ -54,8 +57,14 @@ juju config auditd enable_session_recording=false
 - **File transfers are not recorded.** `scp`, `rsync`, and sftp sessions are passed through
   unrecorded (the tlog pty layer would corrupt binary framing). They are still covered by auditd
   path-watch rules.
+- **Weaker guarantees on containers (LXC).** In session-recording-only mode there is no [no auditd
+  tamper detection](#tamper-detection-&-alerting) for the recording assets.
+  Session recording is a best-effort trail.
 
 ### Tamper detection & alerting
+
+This applies to **VM/bare-metal units only**. Container (LXC) units have no `auditd`, so none of
+the watches or Loki alerts below apply to them.
 
 auditd watches these session-recording assets:
 - recording file and its rotated copies
@@ -67,10 +76,10 @@ auditd watches these session-recording assets:
 - the audit rules themselves
 and records all writes/attribute changes.
 
-Loki alert rules turn the audit logs into pages, but the alerts are paging only on **interactive**
-tampering, which is distinguished by the audit `auid` (login uid). The charm's own legitimate
-activities run in daemon context (`auid` unset) and should be suppressed at the pager while still
-being recorded in the audit log.
+[Loki alert rules](src/loki_alert_rules/audit.yaml) turn the audit logs into pages, but the alerts
+are paging only on **interactive** tampering, which is distinguished by the audit `auid` (login uid).
+The charm's own legitimate activities run in daemon context (`auid` unset) and should be suppressed
+at the pager while still being recorded in the audit log.
 
 
 ### Replay

--- a/README.md
+++ b/README.md
@@ -57,9 +57,8 @@ juju config auditd enable_session_recording=false
 - **File transfers are not recorded.** `scp`, `rsync`, and sftp sessions are passed through
   unrecorded (the tlog pty layer would corrupt binary framing). They are still covered by auditd
   path-watch rules.
-- **Weaker guarantees on containers (LXC).** In session-recording-only mode there is no [no auditd
-  tamper detection](#tamper-detection-&-alerting) for the recording assets.
-  Session recording is a best-effort trail.
+- **Weaker guarantees on containers (LXC).** In session-recording-only mode there is no auditd's
+  tamper detection for the recording assets. Session recording is a best-effort trail.
 
 ### Tamper detection & alerting
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,6 +5,10 @@ description: |
   A Juju charm that deploys and manages auditd on the machine. auditd is the  userspace component
   to the Linux Auditing System. It's responsible for writing audit records to the disk.
 
+  auditd runs on bare-metal or virtual machines only. On LXC containers the charm runs in
+  session-recording-only mode (tlog), skipping auditd; if session recording is also disabled
+  there the unit blocks, as it has nothing to manage.
+
 platforms:
   ubuntu@22.04:amd64:
   ubuntu@24.04:amd64:
@@ -39,7 +43,9 @@ config:
       description: |
         A toggle for tlog SSH session recording. When true (default), every inbound SSH
         login to this unit is recorded on a best-effort basis via a global sshd ForceCommand.
-        Set to false will disable recording entirely.
+        Set to false will disable recording entirely. On LXC containers this is the only
+        managed function (auditd is unavailable), so setting it false there blocks the unit;
+        container recording has no auditd tamper detection.
     session_recording_exclude_groups:
       type: string
       default: ""

--- a/src/charm.py
+++ b/src/charm.py
@@ -18,10 +18,6 @@ from workloads import AuditdConfig, AuditdService, AuditdServiceRestartError
 logger = logging.getLogger(__name__)
 
 
-class PlatformUnsupportedError(Exception):
-    """Error when the platform is not supported."""
-
-
 class AuditdOperatorCharm(ops.CharmBase):
     """Auditd service."""
 
@@ -51,31 +47,36 @@ class AuditdOperatorCharm(ops.CharmBase):
 
     def _on_remove(self, _: ops.RemoveEvent) -> None:
         """Handle remove charm event."""
-        if not self._is_valid_platform():
-            logger.warning("Not removing packages: cannot run on a linux container.")
-            return
-
         self.unit.status = ops.MaintenanceStatus("Removing packages.")
         self.tlog.remove()
-        self.auditd.remove()
+        if self._supports_auditd():
+            self.auditd.remove()
 
     def _on_install_or_upgrade(self, _: tuple[ops.InstallEvent | ops.UpgradeCharmEvent]) -> None:
         """Handle install or upgrade charm event."""
-        if not self._is_valid_platform():
-            logger.error("Not installing package: auditd cannot be run on a linux container.")
-            raise PlatformUnsupportedError("Auditd cannot be run on a linux container.")
+        if not self._supports_auditd():
+            logger.info(
+                "Skipping auditd install: auditd cannot run on a linux container; "
+                "continuing in session-recording-only mode."
+            )
+            return
 
         self.unit.status = ops.MaintenanceStatus("Installing or upgrading auditd package.")
         self.auditd.install()
 
     def _configure_charm(self, _: ops.HookEvent) -> None:
-        """Configure the charm idempotently."""
-        if not self._is_valid_platform():
-            self.unit.status = ops.BlockedStatus("Platform not supported (LXC).")
-            return
+        """Configure the charm idempotently.
 
+        On VM/metal, configures auditd and (optionally) tlog. On lxc containers, auditd is
+        skipped: tlog recording runs when enabled (degraded mode, no tamper detection),
+        otherwise the unit blocks since there is nothing to manage.
+        """
         if not (config := self._get_validated_config()):
             self.unit.status = ops.BlockedStatus("Invalid config. Please check `juju debug-log`.")
+            return
+
+        if not self._supports_auditd():
+            self._configure_charm_container(config)
             return
 
         ok_auditd = self._configure_auditd(config)
@@ -88,15 +89,47 @@ class AuditdOperatorCharm(ops.CharmBase):
         else:
             self.unit.status = ops.ActiveStatus()
 
-    def _is_valid_platform(self) -> bool:
-        """Check if the charm is supported in the current platform.
+    def _configure_charm_container(self, config: dict) -> None:
+        """Configure the charm on a container (session-recording-only mode).
+
+        auditd is unavailable, so tlog runs without tamper-detection audit rules.
+        Session recording enables recording when on, and clears leftover sshd snippet
+        when off.
+
+        Args:
+            config (dict): The validated charm config.
+
+        """
+        if not self._configure_tlog(config, manage_audit_rules=False):
+            if config.get("enable_session_recording", False):
+                self.unit.status = ops.BlockedStatus("Failed to configure tlog recording.")
+            else:
+                self.unit.status = ops.BlockedStatus("Failed to disable tlog recording.")
+            return
+
+        if config.get("enable_session_recording", False):
+            self.unit.status = ops.ActiveStatus(
+                "Session recording only; auditd unsupported on LXC."
+            )
+        else:
+            self.unit.status = ops.BlockedStatus(
+                "auditd unsupported on LXC and session recording disabled."
+            )
+
+    def _supports_auditd(self) -> bool:
+        """Check whether auditd can run on the current platform.
+
+        auditd cannot run inside a linux container.
 
         Returns:
-            True if the charm support the current platform, otherwise False.
+            True if the platform supports auditd, otherwise False.
 
         """
         if get_machine_virt_type() == "lxc":
-            logger.error("auditd cannot be run on a linux container.")
+            logger.info(
+                "auditd cannot run on a linux container; continuing in "
+                "session-recording-only mode."
+            )
             return False
         return True
 
@@ -149,11 +182,14 @@ class AuditdOperatorCharm(ops.CharmBase):
         self.auditd.ensure_audit_rules()
         return True
 
-    def _configure_tlog(self, config: dict) -> bool:
+    def _configure_tlog(self, config: dict, manage_audit_rules: bool = True) -> bool:
         """Configure tlog session recording.
 
         Args:
             config (dict): The validated charm config.
+            manage_audit_rules (bool): Whether tlog should install the auditd
+                tamper-detection rules. Passed False on containers where auditd is
+                unavailable. Defaults to True (VM/metal).
 
         Returns:
             True if tlog recording configured successfully, otherwise False.
@@ -162,7 +198,11 @@ class AuditdOperatorCharm(ops.CharmBase):
         enabled = config.get("enable_session_recording", False)
         exclude_groups = config.get("session_recording_exclude_groups", "")
         try:
-            self.tlog.configure(enabled=enabled, exclude_groups=exclude_groups)
+            self.tlog.configure(
+                enabled=enabled,
+                exclude_groups=exclude_groups,
+                manage_audit_rules=manage_audit_rules,
+            )
         except (TlogServiceError, TlogServiceReloadError) as e:
             logger.error("Failed to configure tlog recording: %s", str(e))
             return False

--- a/src/tlog_workload.py
+++ b/src/tlog_workload.py
@@ -212,7 +212,9 @@ class TlogService:
                 f"(Check tlog installation so '{TLOG_SYSTEM_USER}' exists?): {exc}"
             ) from exc
 
-    def configure(self, enabled: bool, exclude_groups: str) -> None:
+    def configure(
+        self, enabled: bool, exclude_groups: str, manage_audit_rules: bool = True
+    ) -> None:
         """Enable or disable tlog recording.
 
         Args:
@@ -220,6 +222,9 @@ class TlogService:
                 the sshd drop-in and tamper rules (recording off).
             exclude_groups (str): Comma-joined group names. Members of these groups are
                 dropped into their real shell unrecorded. Empty string records everyone.
+            manage_audit_rules (bool): Whether to install the auditd tamper-detection rules.
+                Defaults to True (VM/metal). Callers set this False on containers, where
+                auditd is unavailable so the tamper rules will not be installed.
 
         Raises:
             TlogServiceError: wrapper validation failed (no snippet written).
@@ -239,7 +244,8 @@ class TlogService:
         self._write_tlog_conf()
         self._write_wrapper_atomic(exclude_groups)
         self._write_logrotate()
-        self._ensure_audit_rules()
+        if manage_audit_rules:
+            self._ensure_audit_rules()
         self._write_sshd_snippet()
 
     def _disable(self) -> None:
@@ -286,12 +292,20 @@ class TlogService:
             True if the reload succeeded, False otherwise.
 
         """
-        result = subprocess.run(
-            ["augenrules", "--load"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        try:
+            result = subprocess.run(
+                ["augenrules", "--load"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            logger.warning(
+                "Cannot load audit rules, augenrules not found: %s. "
+                "If auditd is not installed, ignore this warning.",
+                exc,
+            )
+            return False
         if result.returncode != 0:
             logger.warning("Failed to load audit rules: %s", result.stderr.strip())
             return False

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -14,8 +14,8 @@ def test_on_remove_lxc(mock_virt, mock_tlog_remove, mock_auditd_remove):
     ctx = testing.Context(AuditdOperatorCharm)
     state = testing.State()
     ctx.run(ctx.on.remove(), state)
+    mock_tlog_remove.assert_called_once()
     mock_auditd_remove.assert_not_called()
-    mock_tlog_remove.assert_not_called()
 
 
 @patch("charm.AuditdService.remove")
@@ -34,10 +34,8 @@ def test_on_remove_non_lxc(mock_virt, mock_tlog_remove, mock_auditd_remove):
 def test_on_install_lxc(mock_virt, mock_auditd_install):
     ctx = testing.Context(AuditdOperatorCharm)
     state = testing.State()
-    with pytest.raises(testing.errors.UncaughtCharmError) as e:
-        ctx.run(ctx.on.install(), state)
-        mock_auditd_install.assert_not_called()
-    assert isinstance(e.value.__cause__, charm.PlatformUnsupportedError)
+    ctx.run(ctx.on.install(), state)
+    mock_auditd_install.assert_not_called()
 
 
 @patch("charm.AuditdService.install")
@@ -54,10 +52,8 @@ def test_on_install_non_lxc(mock_virt, mock_auditd_install):
 def test_on_upgrade_lxc(mock_virt, mock_auditd_install):
     ctx = testing.Context(AuditdOperatorCharm)
     state = testing.State()
-    with pytest.raises(testing.errors.UncaughtCharmError) as e:
-        ctx.run(ctx.on.install(), state)
-        mock_auditd_install.assert_not_called()
-    assert isinstance(e.value.__cause__, charm.PlatformUnsupportedError)
+    ctx.run(ctx.on.install(), state)
+    mock_auditd_install.assert_not_called()
 
 
 @patch("charm.AuditdService.install")
@@ -70,11 +66,67 @@ def test_on_upgrade_non_lxc(mock_virt, mock_auditd_install):
 
 
 @patch("charm.get_machine_virt_type", return_value="lxc")
-def test_configure_charm_lxc_returns_blocked(mock_virt):
+@patch.object(charm.AuditdOperatorCharm, "_configure_auditd")
+@patch.object(charm.TlogService, "configure")
+def test_configure_charm_lxc_recording_on_active(mock_tlog_conf, mock_auditd, mock_virt):
     ctx = testing.Context(AuditdOperatorCharm)
-    state = testing.State(config={"num_logs": 2, "max_log_file": 512})
+    state = testing.State(
+        config={"num_logs": 2, "max_log_file": 512, "enable_session_recording": True}
+    )
     out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == testing.BlockedStatus("Platform not supported (LXC).")
+    mock_tlog_conf.assert_called_once_with(
+        enabled=True, exclude_groups="", manage_audit_rules=False
+    )
+    mock_auditd.assert_not_called()
+    assert out.unit_status == testing.ActiveStatus(
+        "Session recording only; auditd unsupported on LXC."
+    )
+
+
+@patch("charm.get_machine_virt_type", return_value="lxc")
+@patch.object(charm.AuditdOperatorCharm, "_configure_auditd")
+@patch.object(charm.TlogService, "configure")
+def test_configure_charm_lxc_recording_off_blocked(mock_tlog_conf, mock_auditd, mock_virt):
+    ctx = testing.Context(AuditdOperatorCharm)
+    state = testing.State(
+        config={"num_logs": 2, "max_log_file": 512, "enable_session_recording": False}
+    )
+    out = ctx.run(ctx.on.config_changed(), state)
+    mock_tlog_conf.assert_called_once_with(
+        enabled=False, exclude_groups="", manage_audit_rules=False
+    )
+    mock_auditd.assert_not_called()
+    assert out.unit_status == testing.BlockedStatus(
+        "auditd unsupported on LXC and session recording disabled."
+    )
+
+
+@patch("charm.get_machine_virt_type", return_value="lxc")
+@patch.object(charm.AuditdOperatorCharm, "_configure_auditd")
+@patch.object(charm.TlogService, "configure", side_effect=charm.TlogServiceReloadError("fail"))
+def test_configure_charm_lxc_recording_off_reconcile_failure(
+    mock_tlog_conf, mock_auditd, mock_virt
+):
+    ctx = testing.Context(AuditdOperatorCharm)
+    state = testing.State(
+        config={"num_logs": 2, "max_log_file": 512, "enable_session_recording": False}
+    )
+    out = ctx.run(ctx.on.config_changed(), state)
+    mock_auditd.assert_not_called()
+    assert out.unit_status == testing.BlockedStatus("Failed to disable tlog recording.")
+
+
+@patch("charm.get_machine_virt_type", return_value="lxc")
+@patch.object(charm.AuditdOperatorCharm, "_configure_auditd")
+@patch.object(charm.TlogService, "configure", side_effect=charm.TlogServiceError("fail"))
+def test_configure_charm_lxc_recording_on_tlog_failure(mock_tlog_conf, mock_auditd, mock_virt):
+    ctx = testing.Context(AuditdOperatorCharm)
+    state = testing.State(
+        config={"num_logs": 2, "max_log_file": 512, "enable_session_recording": True}
+    )
+    out = ctx.run(ctx.on.config_changed(), state)
+    mock_auditd.assert_not_called()
+    assert out.unit_status == testing.BlockedStatus("Failed to configure tlog recording.")
 
 
 @pytest.mark.parametrize(
@@ -300,7 +352,9 @@ def test_configure_tlog_calls_configure_with_exclude_groups(mock_tlog_conf, _, m
         }
     )
     out = ctx.run(ctx.on.config_changed(), state)
-    mock_tlog_conf.assert_called_once_with(enabled=True, exclude_groups="warthogs")
+    mock_tlog_conf.assert_called_once_with(
+        enabled=True, exclude_groups="warthogs", manage_audit_rules=True
+    )
     assert out.unit_status == testing.ActiveStatus()
 
 
@@ -313,7 +367,9 @@ def test_configure_tlog_disabled_passes_enabled_false(mock_tlog_conf, _, mock_vi
         config={"num_logs": 2, "max_log_file": 512, "enable_session_recording": False}
     )
     out = ctx.run(ctx.on.config_changed(), state)
-    mock_tlog_conf.assert_called_once_with(enabled=False, exclude_groups="")
+    mock_tlog_conf.assert_called_once_with(
+        enabled=False, exclude_groups="", manage_audit_rules=True
+    )
     assert out.unit_status == testing.ActiveStatus()
 
 

--- a/tests/unit/test_tlog_workload.py
+++ b/tests/unit/test_tlog_workload.py
@@ -203,6 +203,43 @@ def test_configure_enable_ordering(
 @patch.object(TlogService, "_write_tlog_conf")
 @patch.object(TlogService, "_ensure_log_dir")
 @patch.object(TlogService, "is_installed", return_value=True)
+def test_configure_skips_audit_rules_when_unmanaged(
+    mock_installed,
+    mock_ensure,
+    mock_conf,
+    mock_wrapper,
+    mock_validate_tlog,
+    mock_validate_sshd,
+    mock_reload,
+    mock_priv,
+    svc,
+    tmp_path,
+):
+    svc._snippet_path = tmp_path / "99-tlog-recording.conf"
+    svc._log_dir = tmp_path / "tlog"
+    svc._log_file = tmp_path / "tlog" / "sessions.log"
+
+    with (
+        patch("tlog_workload.render_jinja2_template", return_value="new-snippet"),
+        patch("tlog_workload.write_file"),
+        patch.object(TlogService, "_write_logrotate"),
+        patch.object(TlogService, "_ensure_audit_rules") as mock_rules,
+    ):
+        svc.configure(enabled=True, exclude_groups="", manage_audit_rules=False)
+
+    mock_rules.assert_not_called()
+    mock_wrapper.assert_called_once()
+    mock_reload.assert_called_once()
+
+
+@patch.object(TlogService, "_ensure_privileged_recorder")
+@patch.object(TlogService, "reload_sshd")
+@patch.object(TlogService, "validate_tlog")
+@patch.object(TlogService, "validate_sshd")
+@patch.object(TlogService, "_write_wrapper_atomic")
+@patch.object(TlogService, "_write_tlog_conf")
+@patch.object(TlogService, "_ensure_log_dir")
+@patch.object(TlogService, "is_installed", return_value=True)
 def test_configure_threads_exclude_groups_into_wrapper(
     _installed,
     _ensure,
@@ -749,7 +786,12 @@ def test_reload_audit_rules_invokes_augenrules(mock_run, svc):
 )
 def test_reload_audit_rules_failure_does_not_raise(mock_run, svc):
     """Recording must keep working when rule loading fails; failure is logged."""
-    svc._reload_audit_rules()
+    assert svc._reload_audit_rules() is False
+
+
+@patch("tlog_workload.subprocess.run", side_effect=FileNotFoundError("augenrules"))
+def test_reload_audit_rules_missing_binary_returns_false(mock_run, svc):
+    assert svc._reload_audit_rules() is False
 
 
 @patch("tlog_workload.write_file")


### PR DESCRIPTION
Close #32 

This PR makes the following changes to the charm behaviour:
- If deploying to VM/metal: nothing changes
- If deploying to LXC: 
   - ignore `auditd` completely. 
   - If `enable_session_recording=true` (default): install and configure `tlog` for session recording - without adding record-tampering audit rules  
   - If `enable_session_recording=false`: disable session recording, plus, set the charm in blocked state

As auditd doesn't work on LXC, session records by this charm in LXC will not have tampering-proof via audit watch rules. This is an acceptable trade-off for RFO/RCA. Such monitoring should be done in hypervisor level which is not in scope here.

Tests are fully written by Copilot, human reviewed.